### PR TITLE
Remove redundant log

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 tag_name = {new_version}
-current_version = 10.1.0
+current_version = 10.1.1
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 This log should always be updated when doing backwards incompatible changes, resulting in a major version bump. Feel free to add a log for lesser version bumps as well, but for major bumps it's a must.
 
+10.1.1
+-----
+- Changed
+  - "Returned from" log message is now more concise.
+
 10.1.0
 -----
 - Changed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # `@loggo`: automated logging for Python 3
 
 <!--- Don't edit the version line below manually. Let bump2version do it for you. -->
-> Version 10.1.0
+> Version 10.1.1
 
 > You find Python's builtin `logging` module repetitive, tedious and ugly, and the logs you do write with it clash with your otherwise awesome style. `loggo2` is here to help: it automates the boring stuff, simplifies the tricky stuff, hooks up effortlessly to [graylog](https://www.graylog.org/), and keeps an eye out for privacy and security if you need it to.
 

--- a/loggo2/__init__.py
+++ b/loggo2/__init__.py
@@ -1,3 +1,3 @@
 from ._loggo2 import JsonLogFormatter, LocalLogFormatter, Loggo  # noqa: F401
 
-__version__ = "10.1.0"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+__version__ = "10.1.1"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT

--- a/loggo2/_loggo2.py
+++ b/loggo2/_loggo2.py
@@ -34,7 +34,7 @@ CallableOrType = TypeVar("CallableOrType", Callable, type)
 # Strings to be formatted for pre function, post function and error during function
 DEFAULT_FORMS: Mapping[CallableEvent, str] = {
     "called": "*Called {call_signature}",
-    "returned": "*Returned from {call_signature} with {return_type} {return_value}",
+    "returned": "*Returned from {call_signature} with {return_type}",
     "returned_none": "*Returned None from {call_signature}",
     "errored": '*Errored during {call_signature} with {exception_type} "{exception_msg}"',
 }

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def read(fname: str) -> str:
 
 setup(
     name="loggo2",
-    version="10.1.0",  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+    version="10.1.1",  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
     author="Bitpanda GmbH",
     author_email="nosupport@bitpanda.com",
     description="Python logging tools",


### PR DESCRIPTION
`return_value` is present both in `msg` and in `return_value` itself -- sometimes (e.g. solana block description) it's >8k characters, resulting in >16k characters total (because of the duplication), which results in splitting the log message and therefore an invalid JSON