### PR TITLE
Bump version to `10.1.3`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 tag_name = {new_version}
-current_version = 10.1.2
+current_version = 10.1.3
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # `@loggo`: automated logging for Python 3
 
 <!--- Don't edit the version line below manually. Let bump2version do it for you. -->
-> Version 10.1.3
+> Version > Version 10.1.3
 
 > You find Python's builtin `logging` module repetitive, tedious and ugly, and the logs you do write with it clash with your otherwise awesome style. `loggo2` is here to help: it automates the boring stuff, simplifies the tricky stuff, hooks up effortlessly to [graylog](https://www.graylog.org/), and keeps an eye out for privacy and security if you need it to.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # `@loggo`: automated logging for Python 3
 
 <!--- Don't edit the version line below manually. Let bump2version do it for you. -->
-> Version 10.1.2
+> Version 10.1.3
 
 > You find Python's builtin `logging` module repetitive, tedious and ugly, and the logs you do write with it clash with your otherwise awesome style. `loggo2` is here to help: it automates the boring stuff, simplifies the tricky stuff, hooks up effortlessly to [graylog](https://www.graylog.org/), and keeps an eye out for privacy and security if you need it to.
 

--- a/loggo2/__init__.py
+++ b/loggo2/__init__.py
@@ -1,3 +1,3 @@
 from ._loggo2 import JsonLogFormatter, LocalLogFormatter, Loggo  # noqa: F401
 
-__version__ = "10.1.3"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+__version__ = "__version__ = "10.1.3""  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT

--- a/loggo2/__init__.py
+++ b/loggo2/__init__.py
@@ -1,3 +1,3 @@
 from ._loggo2 import JsonLogFormatter, LocalLogFormatter, Loggo  # noqa: F401
 
-__version__ = "10.1.2"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+__version__ = "10.1.3"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def read(fname: str) -> str:
 
 setup(
     name="loggo2",
-    version="10.1.3",  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+    version="version="10.1.3"",  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
     author="Bitpanda GmbH",
     author_email="nosupport@bitpanda.com",
     description="Python logging tools",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def read(fname: str) -> str:
 
 setup(
     name="loggo2",
-    version="10.1.2",  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+    version="10.1.3",  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
     author="Bitpanda GmbH",
     author_email="nosupport@bitpanda.com",
     description="Python logging tools",


### PR DESCRIPTION
This version integrates changes from https://github.com/bitpanda-labs/loggo2/pull/158, notably upgrading the typing-extensions compatibility to be `>=4.2.0,<5.0.0`.